### PR TITLE
Add functions to nmPhoneUtils and 2 new directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To use the directives you need to include `src/nmPhoneNumber.js` as the first fi
 * `dist/utils.js` + `src/nmPhoneUtils.js`: it will attach the `nmPhoneUtils` module as a service in your angular app
 * `src/nmNumeric.js`: it's a directive that will make sure whatever you type will retain only numbers
 * `src/nmRangeLength.js`: it's a directive that will make sure whatever you type will be between a min and max length
-* `src/PhoneNumberSingleInput`: it's a directive that will make sure you are typing an international number (+<prefix>[-<carriere>]-<number>)
-* `src/PhoneNumberMultiInput`: it's a directive that will give you some utilities to handle the validation of an international number given as 3 different inputs: country, carrier, number.
+* `src/PhoneNumberSingleInput`: it's a directive that will make sure you are typing an international number (+<prefix>[-<carrier>]-<number>)
+* `src/PhoneNumberMultiInput`: it's a directive that will give you some utilities to handle the validation of an international number given as a form with 3 different inputs: country, carrier, number.
 
 
 Remember to add the module name into the app definition

--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ bower install --save namshi/nmPhone
 
 ## Use it
 
-You will need to include 2 files into your app:
+If you need only the `nmPhoneUtils` library you can include `dist/utils.js`.
 
-* `dist/utils.js`: it will load `nmPhoneUtils` module (use by the directives)
-* `src/directive.js`: it will load `nmPhoneNumberSingleInput` and `nmPhoneNumber` directives
 
-If you want to use the directives remember to add the module name into the app definition
+To use the directives you need to include `src/nmPhoneNumber.js` as the first file (it will register the module `namshi.nmPhoneNumber`), then, based on what you want to use, you will need to include:
+
+* `dist/utils.js` + `src/nmPhoneUtils.js`: it will attach the `nmPhoneUtils` module as a service in your angular app
+* `src/nmNumeric.js`: it's a directive that will make sure whatever you type will retain only numbers
+* `src/nmRangeLength.js`: it's a directive that will make sure whatever you type will be between a min and max length
+* `src/PhoneNumberSingleInput`: it's a directive that will make sure you are typing an international number (+<prefix>[-<carriere>]-<number>)
+* `src/PhoneNumberMultiInput`: it's a directive that will give you some utilities to handle the validation of an international number given as 3 different inputs: country, carrier, number.
+
+
+Remember to add the module name into the app definition
 
 ```
 angular.module('my_App', [..., 'namshi.nmPhoneNumber', ...]);

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -74,13 +74,41 @@ var nmPhoneUtils =
 	  contains: contains,
 
 	  /**
+	   * load country codes (971, 973, etc.) from config
+	   *
+	   * @param  {Object} phoneSettings
+	   * @return {Array}
+	   */
+	  loadCountryCodes: function loadCountryCodes(phoneSettings) {
+	    return _.map(phoneSettings, function (item) {
+	      return item.phoneCodes.country;
+	    });
+	  },
+
+	  /**
+	   * Get country specific `phoneSetting` object
+	   *
+	   * @param  {Object} phoneSettings
+	   * @param  {string|integer} countryCode
+	   * @return {Object}
+	   */
+	  getCountryPhoneSettings: function getCountryPhoneSettings(phoneSettings, countryCode) {
+	      var phoneSetting = _(phoneSettings).filter(function(item) {
+	          return ''+item.phoneCodes.country === ''+countryCode;
+	        }).value().shift();
+
+	      return phoneSetting && phoneSetting.phoneCodes;
+	  },
+
+
+	  /**
 	   * Will verfy that a given value is in a phone number format.
 	   * The format is defined by a regex (see phoneRegex variable)
 	   *
 	   * @param  {Mixed} value
 	   * @return {Boolean}
 	   */
-	  isValidPhoneNumber: function(value) {
+	  isValidPhoneNumber: function isValidPhoneNumber(value) {
 	    return phoneRegex.test(value);
 	  },
 
@@ -101,9 +129,14 @@ var nmPhoneUtils =
 	   * IF there are any errors it will return the same object
 	   * but all the values are going to be empty.
 	   */
-	  parsePhone: function(phone, phoneSettings) {
+	  parsePhone: function parsePhone(phone, phoneSettings, defaultCountry) {
+	    var eo = _.clone(emptyPhoneObject);
+
 	    if (!phone || !phoneRegex.test(phone)) {
-	      return emptyPhoneObject;
+	      eo.fkCountry = defaultCountry || '';
+	      eo.cellTokens.countryCode = phoneSettings[defaultCountry] ? phoneSettings[defaultCountry].phoneCodes.country : '';
+
+	      return eo;
 	    }
 
 	    var matches = phone.match(phoneRegex);
@@ -113,18 +146,21 @@ var nmPhoneUtils =
 	    });
 
 	    if (!phoneCountryConfig) {
-	      return emptyPhoneObject;
+	      eo.fkCountry = defaultCountry || '';
+	      eo.cellTokens.countryCode = phoneSettings[defaultCountry] ? phoneSettings[defaultCountry].phoneCodes.country : '';
+
+	      return eo;
 	    }
 
 	    var carrierCode = matches[3] || '';
 	    var number = matches[4];
 
 	    return {
-	      fkCountry: phoneCountryConfig.iso2Code,
+	      fkCountry: ''+phoneCountryConfig.iso2Code,
 	      cellTokens: {
-	        countryCode: countryCode,
-	        carrierCode: carrierCode,
-	        number: number
+	        countryCode: !!countryCode ? Number(countryCode) : "",
+	        carrierCode: !!carrierCode ? Number(carrierCode) : "",
+	        number: ''+number
 	      }
 	    };
 	  },
@@ -147,7 +183,7 @@ var nmPhoneUtils =
 	   * @param  {Object} phoneSettings
 	   * @return {Object}
 	   */
-	  validateCountry: function(countryId, phoneSettings) {
+	  validateCountry: function validateCountry(countryId, phoneSettings) {
 	    if (!countryId) {
 	      return {valid: false, errors: ['empty']};
 	    }
@@ -177,7 +213,7 @@ var nmPhoneUtils =
 	   * @param  {Object} phoneSettings
 	   * @return {Object}
 	   */
-	  validateCarrierCode: function(carrierCode, countryId, phoneSettings) {
+	  validateCarrierCode: function validateCarrierCode(carrierCode, countryId, phoneSettings) {
 	    if (!countryId) {
 	      return {
 	        valid: false
@@ -228,7 +264,7 @@ var nmPhoneUtils =
 	   * @param  {Number} max     Max number length
 	   * @return {Object}
 	   */
-	  validateNumber: function(number, min, max) {
+	  validateNumber: function validateNumber(number, min, max) {
 	    if (!number) {
 	      return {
 	        valid: false,
@@ -268,8 +304,8 @@ var nmPhoneUtils =
 	   * @param  {String} value
 	   * @return {String}
 	   */
-	  extractNumbers: function (value) {
-	    return value.replace(/[^\d]+/g, '');
+	  extractNumbers: function extractNumbers(value) {
+	    return value ? value.replace(/[^\d]+/g, '') : '';
 	  },
 
 	  /**
@@ -279,8 +315,38 @@ var nmPhoneUtils =
 	   * @param  {Number} length
 	   * @return {String}
 	   */
-	  shortenToLength: function (value, length) {
+	  shortenToLength: function shortenToLength(value, length) {
 	    return value.substring(0, length);
+	  },
+
+	  /**
+	   * Format the phoneData object into a string of the form:
+	   *
+	   * +<countrycode>-[<carriercode>-]<number>
+	   *
+	   * @param  {Object} phoneData
+	   * @return {String}
+	   */
+	  getFormattedNumber: function getFormattedNumber(phoneData) {
+	    if (!phoneData.cellTokens) {
+	      return '';
+	    }
+
+	    return [
+	        (!!phoneData.cellTokens.countryCode ? '+' + phoneData.cellTokens.countryCode : ''),
+	        (''+phoneData.cellTokens.carrierCode),
+	        (''+phoneData.cellTokens.number),
+	      ].filter(function(v) { return !_.isEmpty(v); }).join('-');
+	  },
+
+	  isPhoneDataValid: function isPhoneDataValid(phoneData, phoneSettings, min, max) {
+	    return (
+	      !!phoneData.fkCountry &&
+	      this.validateCountry(phoneData.fkCountry, phoneSettings).valid &&
+	      this.validateCarrierCode(phoneData.cellTokens.carrierCode, phoneData.fkCountry, phoneSettings).valid &&
+	      !!phoneData.cellTokens.number &&
+	      this.validateNumber(phoneData.cellTokens.number, min, max).valid
+	    );
 	  }
 	}
 

--- a/src/nmNumeric.js
+++ b/src/nmNumeric.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * This directive prevents any character inputs other than numbers to be set in a text field
+ * by instantiating and adding a 'numericValidator' on the modelCtrl
+ *
+ * usage:
+ *
+ * <input type="text" data-nm-numeric />
+ *
+ */
+angular.module('namshi.nmPhoneNumber').directive('nmNumeric', function () {
+  return {
+    require:  'ngModel',
+    priority: 500,
+    link:     function (scope, element, attrs, modelCtrl) {
+      /**
+       * Updates the view on the current field to newValue
+       * @param newValue
+       */
+      var updateView = function (newValue) {
+        modelCtrl.$setViewValue(newValue);
+        modelCtrl.$render();
+      };
+
+      /**
+       * Parser to make sure that users are not allowed to enter characters other than numerics
+       * in the field
+       *
+       * @param input
+       * @returns {*}
+       */
+      var numericValidator = function (input) {
+        var output;
+
+        if (_.isString(input)) {
+          output = input.replace(/[^0-9]/g, '');
+
+          if (input !== output) {
+            updateView(output);
+          }
+        }
+
+        return output;
+      };
+
+      modelCtrl.$parsers.push(numericValidator);
+    }
+  };
+});

--- a/src/nmNumeric.js
+++ b/src/nmNumeric.js
@@ -9,7 +9,7 @@
  * <input type="text" data-nm-numeric />
  *
  */
-angular.module('namshi.nmPhoneNumber').directive('nmNumeric', function () {
+angular.module('namshi.nmPhoneNumber').directive('nmNumeric', function (nmPhoneUtils) {
   return {
     require:  'ngModel',
     priority: 500,
@@ -23,28 +23,7 @@ angular.module('namshi.nmPhoneNumber').directive('nmNumeric', function () {
         modelCtrl.$render();
       };
 
-      /**
-       * Parser to make sure that users are not allowed to enter characters other than numerics
-       * in the field
-       *
-       * @param input
-       * @returns {*}
-       */
-      var numericValidator = function (input) {
-        var output;
-
-        if (_.isString(input)) {
-          output = input.replace(/[^0-9]/g, '');
-
-          if (input !== output) {
-            updateView(output);
-          }
-        }
-
-        return output;
-      };
-
-      modelCtrl.$parsers.push(numericValidator);
+      modelCtrl.$parsers.push(nmPhoneUtils.getNumericValidator(updateView));
     }
   };
 });

--- a/src/nmPhoneNumber.js
+++ b/src/nmPhoneNumber.js
@@ -1,0 +1,6 @@
+'use strict';
+
+/**
+ * Registers the `namshi.nmPhoneNumber` module
+ */
+angular.module('namshi.nmPhoneNumber', []);

--- a/src/nmPhoneNumberMultiInput.js
+++ b/src/nmPhoneNumberMultiInput.js
@@ -1,25 +1,20 @@
 'use strict';
 
+/**
+ * This directive defines utilities to validate an international phone number based on 3 inputs:
+ *
+ * - country
+ * - carrier
+ * - number
+ *
+ * It will expose helper methods to run the validation on single fields and the three combined.
+ *
+ * You can specify which country are allowed and which validation to perform on each. (see `test/utilsTest.js`)
+ *
+ */
 angular
-  .module('namshi.nmPhoneNumber', [])
-  .directive('nmPhoneNumberSingleInput', function () {
-     return {
-        require: 'ngModel',
-        link: function($scope, elem, attr, ngModel) {
-          ngModel.$parsers.unshift(function(value) {
-            var isValid = nmPhoneUtils.isValidPhoneNumber(value);
-            ngModel.$setValidity('nmPhoneNumberSingleInput', isValid);
-            return isValid ? value : undefined;
-          });
-
-          ngModel.$formatters.unshift(function(value) {
-            ngModel.$setValidity('nmPhoneNumberSingleInput', nmPhoneUtils.isValidPhoneNumber(value));
-            return value;
-          });
-        }
-     }
-  })
-  .directive('nmPhoneNumber', function () {
+  .module('namshi.nmPhoneNumber')
+  .directive('nmPhoneNumberMultiInput', function () {
     return {
       scope: {
         phoneNumber: '=phoneNumber',
@@ -49,7 +44,7 @@ angular
         $scope.phoneData = nmPhoneUtils.parsePhone($scope.phoneNumber, $scope.phoneSettings);
         $scope.getProperty = getProperty;
 
-        $scope.changeCarrierCode = function() {
+        $scope.onContrySelected = function(options) {
           resetValidation();
           $scope.validateCountry();
 
@@ -65,7 +60,7 @@ angular
           cellTokens.carrierCode = phoneCodes.carrierCodes[0] ? phoneCodes.carrierCodes[0].toString() : null;
 
           $scope.validateCarrierCode();
-          $scope.validateNumber({trimNumber: false});
+          !options.validateNumber ? null : $scope.validateNumber({trimNumber: false});
         };
 
         $scope.savePhone = function (phoneData) {

--- a/src/nmPhoneNumberSingleInput.js
+++ b/src/nmPhoneNumberSingleInput.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * This directive can be used to validate an international phone number that is being typed in a single input text.
+ *
+ * the phone number is validated agains a regura expression that you can find in `nmPhoneUtils.isValidPhoneNumber` function
+ */
+angular
+  .module('namshi.nmPhoneNumber')
+  .directive('nmPhoneNumberSingleInput', function () {
+    return {
+      require: 'ngModel',
+      link: function($scope, elem, attr, ngModel) {
+        ngModel.$parsers.unshift(function(value) {
+          var isValid = nmPhoneUtils.isValidPhoneNumber(value);
+          ngModel.$setValidity('nmPhoneNumberSingleInput', isValid);
+          return isValid ? value : undefined;
+        });
+
+        ngModel.$formatters.unshift(function(value) {
+          ngModel.$setValidity('nmPhoneNumberSingleInput', nmPhoneUtils.isValidPhoneNumber(value));
+          return value;
+        });
+      }
+    }
+  });

--- a/src/nmPhoneUtils.js
+++ b/src/nmPhoneUtils.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * Register the `nmPhoneUtils` library as a service in an angular app
+ */
+angular
+  .module('namshi.nmPhoneNumber')
+  .factory('nmPhoneUtils', function() {
+    return nmPhoneUtils;
+  });

--- a/src/nmRangeLength.js
+++ b/src/nmRangeLength.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * This directive validates min and max length of characters to be set on a field by instantiating and adding a
+ * minLengthValidator and maxLengthValidator on the ctrl
+ *
+ * It marks the field as ng-invalid-maxlength if more than 'maxlength' characters have been set
+ * or ng-invalid-minlength if less than 'minlength' characters are set.
+ *
+ * It also prevents user from entering more than 'maxLength' number of characters on the field
+ *
+ * usage:
+ *
+ * <input name="myField" type="text" data-nm-range-length minLength="2" maxLength="5" />
+ *
+ * `minLength`              the minimum number of characters that 'myField' should accept
+ *                          (marks 'myField' as ng-invalid-minlength if less number of characters is set)
+ *
+ * `maxLength`              the maximum characters that the 'myField' should accept
+ *                          (marks 'myField' as ng-invalid-maxlength if more number of characters is set)
+ *
+ * Note: html5 compatible browsers will automatically take care of not allowing a field to exceed the maximum number
+ * of characters. This functionality is also implemented in this directive for non-HTML5 browsers
+ *
+ */
+angular.module('namshi.nmPhoneNumber').directive('nmRangeLength', function () {
+  return {
+    restrict: 'A',
+    require:  'ngModel',
+    priority: 1000,
+    scope:    {
+      maxlength: '=',
+      minlength: '='
+    },
+    link:     function (scope, elem, attr, ctrl) {
+      /**
+       * Parser and formatter to invalidate a field which its value length exceeded the maximum number of
+       * allowed characters
+       *
+       * @param value
+       * @returns {*}
+       */
+      var maxLengthValidator = function (value) {
+        var maxlength = parseInt(scope.maxlength, 10) || 15;
+        var isValid = ctrl.$isEmpty(value) || value.length <= maxlength;
+        ctrl.$setValidity('maxlength', isValid);
+
+        if (!(isValid || ctrl.$isEmpty(value))) {
+          value = value.substring(0, maxlength);
+          ctrl.$setViewValue(value);
+          ctrl.$render();
+        }
+
+        return value;
+      };
+
+      /**
+       * Parser and Formatter to invalidate a field which its value length goes below the minimum number of
+       * allowed characters
+       *
+       * @param value
+       * @returns {*}
+       */
+      var minLengthValidator = function (value) {
+        var minlength = parseInt(scope.minlength, 10) || 1;
+        var isValid = ctrl.$isEmpty(value) || value.length >= minlength;
+        ctrl.$setValidity('minlength', isValid);
+
+        return value;
+      };
+
+      ctrl.$parsers.push(maxLengthValidator);
+      ctrl.$parsers.push(minLengthValidator);
+      ctrl.$formatters.push(maxLengthValidator);
+      ctrl.$formatters.push(minLengthValidator);
+    }
+  };
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,16 @@ function contains(list, item) {
   return _(list).map(_.toString).includes(_.toString(item));
 };
 
+/**
+ * Extracts only the numeric characters from a string.
+ *
+ * @param  {String} value
+ * @return {String}
+ */
+function extractNumbers(value) {
+  return value ? value.replace(/[^0-9]+/g, '') : '';
+};
+
 var emptyPhoneObject = {
   fkCountry: '',
   cellTokens: {
@@ -257,9 +267,7 @@ var nmPhoneUtils = {
    * @param  {String} value
    * @return {String}
    */
-  extractNumbers: function extractNumbers(value) {
-    return value ? value.replace(/[^\d]+/g, '') : '';
-  },
+  extractNumbers: extractNumbers,
 
   /**
    * Shorten a string to a given length if it is longr than that.
@@ -300,6 +308,30 @@ var nmPhoneUtils = {
       !!phoneData.cellTokens.number &&
       this.validateNumber(phoneData.cellTokens.number, min, max).valid
     );
+  },
+
+  /**
+   * Return the numeric validator function.
+   * The numericValidator function will filter out non numeric characters from the given input and call the callback.
+   * The callback is invoked only if one or more characters are removed from the input string
+   *
+   * @param callback
+   * @returns {*}
+   */
+  getNumericValidator: function getNumericValidator(callback) {
+    return function numericValidator(input) {
+      var output;
+
+      if (_.isString(input)) {
+        output = extractNumbers(input);
+
+        if (input !== output) {
+          callback(output);
+        }
+      }
+
+      return output;
+    };
   }
 }
 

--- a/test/utilsTest.js
+++ b/test/utilsTest.js
@@ -37,17 +37,17 @@ describe('nmPhoneUtils', function() {
 
       expect(utils.parsePhone('+971-52-000000', phoneSettings)).to.deep.equal({
         "cellTokens": {
-          "carrierCode": "52",
-          "countryCode": "971",
+          "carrierCode": 52,
+          "countryCode": 971,
           "number": "000000"
         },
         "fkCountry": "AE"
       });
 
-      expect(utils.parsePhone('+966-00-000000', phoneSettings)).to.deep.equal({
+      expect(utils.parsePhone('+966-50-000000', phoneSettings)).to.deep.equal({
         "cellTokens": {
-          "carrierCode": "00",
-          "countryCode": "966",
+          "carrierCode": 50,
+          "countryCode": 966,
           "number": "000000"
         },
         "fkCountry": "SA"
@@ -56,7 +56,7 @@ describe('nmPhoneUtils', function() {
       expect(utils.parsePhone('+973-000000', phoneSettings)).to.deep.equal({
         "cellTokens": {
           "carrierCode": "",
-          "countryCode": "973",
+          "countryCode": 973,
           "number": "000000"
         },
         "fkCountry": "BH"
@@ -65,13 +65,13 @@ describe('nmPhoneUtils', function() {
       expect(utils.parsePhone('+973000000', phoneSettings)).to.deep.equal({
         "cellTokens": {
           "carrierCode": "",
-          "countryCode": "973",
+          "countryCode": 973,
           "number": "000000"
         },
         "fkCountry": "BH"
       });
 
-      expect(utils.parsePhone('+not-00-valid', phoneSettings)).to.deep.equal({
+      expect(utils.parsePhone('+not-50-valid', phoneSettings)).to.deep.equal({
         "cellTokens": {
           "carrierCode": "",
           "countryCode": "",
@@ -89,7 +89,7 @@ describe('nmPhoneUtils', function() {
         "fkCountry": ""
       });
 
-      expect(utils.parsePhone('+999-00-000000', phoneSettings)).to.deep.equal({
+      expect(utils.parsePhone('+999-50-000000', phoneSettings)).to.deep.equal({
         "cellTokens": {
           "carrierCode": "",
           "countryCode": "",
@@ -185,6 +185,205 @@ describe('nmPhoneUtils', function() {
       done();
     });
   });
+
+  describe('extractNumbers', function() {
+    it('should return only numbers inside a string and an empty string if none is found', function(done) {
+
+      expect(utils.extractNumbers('h8h48hf8h4hf38h92')).to.equal('848843892');
+      expect(utils.extractNumbers('12345')).to.equal('12345');
+      expect(utils.extractNumbers('')).to.equal('');
+      expect(utils.extractNumbers(undefined)).to.equal('');
+      expect(utils.extractNumbers('hello')).to.equal('');
+
+      done();
+    });
+  });
+
+  describe('getFormattedNumber', function() {
+    it('should return the phone number as a tring given an object', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": 50,
+          "countryCode": 971,
+          "number": "0000000"
+        },
+        "fkCountry": "AE"
+      };
+
+      expect(utils.getFormattedNumber(phoneData)).to.equal('+971-50-0000000');
+
+      done();
+    });
+
+    it('should return the phone number as a tring given an object without carrier code', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": "",
+          "countryCode": 444,
+          "number": "0000000"
+        },
+        "fkCountry": ""
+      };
+
+      expect(utils.getFormattedNumber(phoneData)).to.equal('+444-0000000');
+
+      done();
+    });
+
+    it('should return an empty string for an empty object or empty fields', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": "",
+          "countryCode": "",
+          "number": ""
+        },
+        "fkCountry": ""
+      };
+
+      expect(utils.getFormattedNumber(phoneData)).to.equal('');
+      expect(utils.getFormattedNumber({})).to.equal('');
+
+      done();
+    });
+  });
+
+  describe('isPhoneDataValid', function() {
+    it('should return true for a valid phoneDataObject', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": 50,
+          "countryCode": 971,
+          "number": "0000000"
+        },
+        "fkCountry": "AE"
+      };
+
+      expect(utils.isPhoneDataValid(phoneData, phoneSettings)).to.equal(true);
+
+      done();
+    });
+
+    it('should return true for a valid phoneDataObject', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": "",
+          "countryCode": 973,
+          "number": "000000"
+        },
+        "fkCountry": "BH"
+      };
+
+      expect(utils.isPhoneDataValid(phoneData, phoneSettings)).to.equal(true);
+
+      done();
+    });
+
+    it('should return false for an invalid phoneData object', function(done) {
+
+      expect(utils.isPhoneDataValid({}, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({"cellTokens": {}}, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({"fkCountry": ""}, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({
+        "cellTokens": {
+          "carrierCode": "",
+          "countryCode": "971",
+          "number": "0000000"
+        },
+        "fkCountry": "AE"
+      }, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({
+        "cellTokens": {
+          "carrierCode": "50",
+          "countryCode": "",
+          "number": "0000000"
+        },
+        "fkCountry": ""
+      }, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({
+        "cellTokens": {
+          "carrierCode": "50",
+          "countryCode": "971",
+          "number": ""
+        },
+        "fkCountry": "AE"
+      }, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({
+        "cellTokens": {
+          "carrierCode": "50",
+          "countryCode": "971",
+          "number": "000"
+        },
+        "fkCountry": "AE"
+      }, phoneSettings, 7, 7)).to.equal(false);
+      expect(utils.isPhoneDataValid({
+        "cellTokens": {
+          "carrierCode": "50",
+          "countryCode": "971",
+          "number": "00000000"
+        },
+        "fkCountry": "AE"
+      }, phoneSettings, 7, 7)).to.equal(false);
+
+      /** NOTE: TO BE FIXED. This will end up returning true ! */
+      // expect(utils.isPhoneDataValid({
+      //   "cellTokens": {
+      //     "carrierCode": "50",
+      //     "countryCode": "",
+      //     "number": "0000000"
+      //   },
+      //   "fkCountry": "AE"
+      // }, phoneSettings, 7, 7)).to.equal(false);
+
+      done();
+    });
+
+    it('should return an empty string for an empty object or empty fields', function(done) {
+
+      var phoneData = {
+        "cellTokens": {
+          "carrierCode": "",
+          "countryCode": "",
+          "number": ""
+        },
+        "fkCountry": ""
+      };
+
+      expect(utils.getFormattedNumber(phoneData)).to.equal('');
+      expect(utils.getFormattedNumber({})).to.equal('');
+
+      done();
+    });
+  });
+
+  describe('loadCountryCodes', function() {
+    it('should return the list of country codes in the settings', function(done) {
+
+      expect(utils.loadCountryCodes(phoneSettings)).to.deep.equal([971, 966, 973]);
+
+      done();
+    });
+  });
+
+  describe('getCountryPhoneSettings', function() {
+    it('should return the country phone setting object for the given country, or return undefined', function(done) {
+
+      expect(utils.getCountryPhoneSettings(phoneSettings, 971)).to.deep.equal({
+        "carrierCodes": [50,52,54,55,56],
+        "country": 971,
+        "maxlength": 7,
+        "minlength": 7
+      });
+      expect(utils.getCountryPhoneSettings(phoneSettings, 39)).to.equal(undefined);
+
+      done();
+    });
+  });
+
 });
 
 var phoneSettings = {

--- a/test/utilsTest.js
+++ b/test/utilsTest.js
@@ -384,6 +384,33 @@ describe('nmPhoneUtils', function() {
     });
   });
 
+  describe('getNumericValidator', function() {
+    it('should return a function that will filter out not numeric characters', function(done) {
+
+      var test = function(result) {
+        expect(result).to.equal('012345');
+        done();
+      }
+
+      utils.getNumericValidator(test)('a0123b45');
+    });
+
+    it('should not call the callback if the the input it is already numeric', function(done) {
+      var counter = 0;
+      var test = function(result) {
+        counter++;
+        expect(result).to.equal('012345');
+      }
+
+      var result =utils.getNumericValidator(test)('a0123b45');
+      result = utils.getNumericValidator(test)('012345');
+
+      expect(result).to.equal('012345');
+      expect(counter).to.equal(1);
+      done();
+    });
+  });
+
 });
 
 var phoneSettings = {


### PR DESCRIPTION
This PR add some more utils functions and 2 new directives nmNumeric and nmRangeLength.

**nmNumeric**: is a directive that will make sure that whatever you type in an input text it will accept only numbers

**nmRangeLength**: it's a directive that will prevent a string from exceeding a certain `max` length and it will mark the input field as invalid if the string is less then a `min` length.

With this PR we are  also splitting each directive/service on it's own file. this way if you want to load a single directive or just the `nmPhoneUtils` service, you can .

Reviewers @odino @shidhincr @Mohamed-amin 
