### PR TITLE
Update phone regex to accept one digit country codes and more dashes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ var emptyPhoneObject = {
 /**
  * @see https://www.debuggex.com/r/tcX_Ez3vptR8n0Ff
  */
-var phoneRegex = /^[00|\+]+([0-9]{2,3})(\-([0-9]{1,2}))?[\-]?([0-9]{6,8})$/;
+var phoneRegex = /^(00|\+)[0-9]{2,3}[\-\s0-9]{9,13}$/;
 
 var nmPhoneUtils = {
   contains: contains,


### PR DESCRIPTION
Given this valid phone number as an example` +1-231-231-2312`, the old regex was rejecting it.
With the new regex, it will work fine.

